### PR TITLE
Fix error in phantomjs download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN pip install s3cmd
 
 # phantomjs install
 ENV PHANTOMJS_VERSION 2.1.1
-RUN wget -U "wget" --wait=5 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 \
+RUN wget -U "wget" --wait=5 https://github.com/paladox/phantomjs/releases/download/2.1.7/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 \
 &&  tar xf phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 \
 &&  mv     phantomjs-${PHANTOMJS_VERSION}-linux-x86_64/bin/phantomjs /usr/bin/phantomjs \
 &&  rm -rf phantomjs-${PHANTOMJS_VERSION}-linux-x86_64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN pip install s3cmd
 
 # phantomjs install
 ENV PHANTOMJS_VERSION 2.1.1
-RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 \
+RUN wget -U "wget" --wait=5 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 \
 &&  tar xf phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 \
 &&  mv     phantomjs-${PHANTOMJS_VERSION}-linux-x86_64/bin/phantomjs /usr/bin/phantomjs \
 &&  rm -rf phantomjs-${PHANTOMJS_VERSION}-linux-x86_64 \


### PR DESCRIPTION
phantomjsをダウンロードする時に頻繁に「ERROR 403: Forbidden.」が出るのでその対策。
- `wget` でUserAgentとリトライ時のwaitする秒数をつけるようにした
- phantomjsのダウンロード先をbitbucketからgithubのミラーに変更
  - BitbucketはRate limitがあるらしい
  - ttps://github.com/ariya/phantomjs/issues/13953#issuecomment-175749630

10回くらいビルドしてみて問題なければマージ予定
